### PR TITLE
Remove non-existent entry point from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,4 @@ setuptools.setup(
         "Programming Language :: Python :: 3",
         "Operating System :: OS Independent",
     ),
-    entry_points="""[console_scripts]
-            kin=kin:main""",
 )


### PR DESCRIPTION
This PR removes a non-existent `kin=kin:main` entry point from the setup.py script. It's not clear to me why this was added in the first place so please correct me if this functionality is under active development.