### PR TITLE
Remove python 3.10 tests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,6 @@ classifiers =
     Programming Language :: Python :: 3 :: Only
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
-    Programming Language :: Python :: 3.10
     Topic :: Scientific/Engineering :: Artificial Intelligence
     Topic :: Scientific/Engineering :: Image Processing
     Topic :: Scientific/Engineering :: Visualization

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,13 @@
 # For more information about tox, see https://tox.readthedocs.io/en/latest/
 [tox]
-envlist = py{38,39,310}-{linux,macos,windows}
+envlist = py{38,39}-{linux,macos,windows}
 isolated_build=true
 
 [gh-actions]
 python =
     3.8: py38
     3.9: py39
-    3.10: py310
-    
+
 [gh-actions:env]
 PLATFORM =
     ubuntu-latest: linux
@@ -16,11 +15,11 @@ PLATFORM =
     windows-latest: windows
 
 [testenv]
-platform = 
+platform =
     macos: darwin
     linux: linux
     windows: win32
-passenv = 
+passenv =
     CI
     GITHUB_ACTIONS
     DISPLAY XAUTHORITY


### PR DESCRIPTION
Lost within the test log we find `RuntimeWarning: NumPy 1.21.0 may not yet support Python 3.10`, explaining why numpy does not build on windows (wheels are only available for more recent versions of numpy). I think it's fine to get rid of the tests on 3.10 for now (as I suppose the pin to numpy was necessary).

