### PR TITLE
Update setup.py

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-11, windows-latest]
-        python-version: [3.8, 3.9]
+        python-version: [3.9, "3.10"]
         include:
           - os: ubuntu-latest
             path: ~/.cache/pip

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setuptools.setup(
         "ipython",
         "ipython-genutils",
         "matplotlib>=3.0.3",
-        "numpy",
+        "numpy<1.25",
         "pandas>=1.0",
         "python-dateutil",
         "pyyaml",

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setuptools.setup(
         "requests",
         "setuptools",
         "scikit-image",
-        "scikit-learn",
+        "scikit-learn<1.2.2",
         "scikit-kinematics",
         "scipy",
         "tables",


### PR DESCRIPTION
- pin numpy > 1.25 (for numba)
- pin sklearn < 1.2.2
- drop python 3.8 support