### PR TITLE
fix deprecated slicing

### DIFF
--- a/src/dlc2kinematics/joint_analysis.py
+++ b/src/dlc2kinematics/joint_analysis.py
@@ -101,10 +101,10 @@ def compute_joint_angles(
 
         def filter_low_prob(cols, prob):
             mask = cols.iloc[:, 2] < prob
-            cols.loc[mask, :2] = np.nan
+            cols.iloc[mask, :2] = np.nan
             return cols
 
-        df = df.groupby("bodyparts", axis=1).apply(filter_low_prob, prob=pcutoff)
+        df = df.groupby("bodyparts", axis=1, group_keys=False).apply(filter_low_prob, prob=pcutoff)
 
     angle_names = list(joints_dict)
     if not destfolder:


### PR DESCRIPTION
On pandas>=2 `loc` cannot slice numerically anymore. To avoid duplication of the level used for groupby `group_keys=False`

Addresses #36 and #42 