### PR TITLE
Fix compute_joint_angles

### DIFF
--- a/src/dlc2kinematics/joint_analysis.py
+++ b/src/dlc2kinematics/joint_analysis.py
@@ -129,13 +129,14 @@ def compute_joint_angles(
         angles = dict()
         for joint, bpts in joints_dict.items():
             print(f"Computing joint angles for {joint}")
-            temp = df.loc(axis=1)[:, bpts]
             if is_multianimal:
+                temp = df.loc(axis=1)[:, :, bpts]
                 for animal, frame in temp.groupby(level="individuals", axis=1):
                     angles[f"{joint}_{animal}"] = frame.apply(
                         auxiliaryfunctions.jointangle_calc, axis=1
                     ).values
             else:
+                temp = df.loc(axis=1)[:, bpts]
                 angles[joint] = temp.apply(
                     auxiliaryfunctions.jointangle_calc, axis=1
                 ).values

--- a/src/dlc2kinematics/joint_analysis.py
+++ b/src/dlc2kinematics/joint_analysis.py
@@ -129,8 +129,7 @@ def compute_joint_angles(
         angles = dict()
         for joint, bpts in joints_dict.items():
             print(f"Computing joint angles for {joint}")
-            mask = df.columns.get_level_values("bodyparts").isin(bpts)
-            temp = df.loc[:, mask]
+            temp = df.loc(axis=1)[:, bpts]
             if is_multianimal:
                 for animal, frame in temp.groupby(level="individuals", axis=1):
                     angles[f"{joint}_{animal}"] = frame.apply(


### PR DESCRIPTION
Bug caught by Ted Brierley https://forum.image.sc/t/dlc2kinematics-compute-joint-angles/86469, noting that the order in which angles were defined in `joints_dict` had no effect on the output. This is because the DataFrame was indexed with a boolean mask, rather than directly with the list of keypoints; `temp` thus always had the same column order.